### PR TITLE
Use instance of DateTimeFormatter instead of format string in Jsr310ModuleConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,20 @@ modelMapper.registerModule(new Jsr310Module());
 We also support for configuration.
 
 ```java
+// using String patterns
 Jsr310ModuleConfig config = Jsr310ModuleConfig.builder()
     .dateTimePattern("yyyy-MM-dd HH:mm:ss") // default is yyyy-MM-dd HH:mm:ss
     .datePattern("yyyy-MM-dd") // default is yyyy-MM-dd
     .zoneId(ZoneOffset.UTC) // default is ZoneId.systemDefault()
+    .build()
+modelMapper.registerModule(new Jsr310Module(config));
+```
+```java
+// using DateTimeFormatter directly
+Jsr310ModuleConfig config = Jsr310ModuleConfig.builder()
+    .dateTimeFormatter(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    .dateFormatter(DateTimeFormatter.ISO_LOCAL_DATE)
+    .zoneId(ZoneOffset.UTC)
     .build()
 modelMapper.registerModule(new Jsr310Module(config));
 ```

--- a/datetime/src/main/java/org/modelmapper/module/jsr310/FromTemporalConverter.java
+++ b/datetime/src/main/java/org/modelmapper/module/jsr310/FromTemporalConverter.java
@@ -6,7 +6,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.Date;
@@ -71,7 +70,7 @@ public class FromTemporalConverter implements ConditionalConverter<Temporal, Obj
       LocalDate source = (LocalDate) mappingContext.getSource();
       Class<?> destinationType = mappingContext.getDestinationType();
       if (destinationType.equals(String.class))
-        return DateTimeFormatter.ofPattern(config.getDatePattern())
+        return config.getDateFormatter()
             .format(source);
 
       LocalDateTime localDateTime = source.atStartOfDay();
@@ -98,7 +97,7 @@ public class FromTemporalConverter implements ConditionalConverter<Temporal, Obj
   private Object convertLocalDateTime(LocalDateTime source, MappingContext<?, ?> mappingContext) {
     Class<?> destinationType = mappingContext.getDestinationType();
     if (destinationType.equals(String.class))
-      return DateTimeFormatter.ofPattern(config.getDateTimePattern())
+      return config.getDateTimeFormatter()
           .format(source);
 
     Instant instant = source.atZone(config.getZoneId()).toInstant();
@@ -108,7 +107,7 @@ public class FromTemporalConverter implements ConditionalConverter<Temporal, Obj
   private Object convertOffsetDateTime(OffsetDateTime source, MappingContext<?, ?> mappingContext) {
     Class<?> destinationType = mappingContext.getDestinationType();
     if (destinationType.equals(String.class))
-      return DateTimeFormatter.ofPattern(config.getDateTimeOffsetPattern())
+      return config.getDateTimeOffsetFormatter()
               .format(source);
 
     Instant instant = source.toInstant();
@@ -118,7 +117,7 @@ public class FromTemporalConverter implements ConditionalConverter<Temporal, Obj
   private Object convertInstant(Instant source, MappingContext<?, ?> mappingContext) {
     Class<?> destinationType = mappingContext.getDestinationType();
     if (destinationType.equals(String.class))
-      return DateTimeFormatter.ofPattern(config.getDateTimePattern())
+      return config.getDateTimeFormatter()
           .withZone(config.getZoneId())
           .format(source);
     else if (Date.class.isAssignableFrom(destinationType))

--- a/datetime/src/main/java/org/modelmapper/module/jsr310/Jsr310ModuleConfig.java
+++ b/datetime/src/main/java/org/modelmapper/module/jsr310/Jsr310ModuleConfig.java
@@ -1,8 +1,8 @@
 package org.modelmapper.module.jsr310;
 
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -14,21 +14,89 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class Jsr310ModuleConfig {
   private static final String DEFAULT_DATE_PATTERN = "yyyy-MM-dd";
   private static final String DEFAULT_DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm:ss";
   private static final String DEFAULT_DATE_TIME_OFFSET_PATTERN = "yyyy-MM-dd HH:mm:ssX";
   private static final String DEFAULT_TIME_PATTERN = "HH:mm:ss";
 
-  @Builder.Default
-  private String datePattern = DEFAULT_DATE_PATTERN;
-  @Builder.Default
-  private String dateTimePattern = DEFAULT_DATE_TIME_PATTERN;
-  @Builder.Default
-  private String dateTimeOffsetPattern = DEFAULT_DATE_TIME_OFFSET_PATTERN;
-  @Builder.Default
-  private String timePattern = DEFAULT_TIME_PATTERN;
-  @Builder.Default
+  private DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(DEFAULT_DATE_PATTERN);
+  private DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DEFAULT_DATE_TIME_PATTERN);
+  private DateTimeFormatter dateTimeOffsetFormatter = DateTimeFormatter.ofPattern(DEFAULT_DATE_TIME_OFFSET_PATTERN);
+  private DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern(DEFAULT_TIME_PATTERN);
   private ZoneId zoneId = ZoneId.systemDefault();
+
+  public void setDatePattern(String datePattern) {
+    this.setDateFormatter(DateTimeFormatter.ofPattern(datePattern));
+  }
+
+  public void setDateTimePattern(String dateTimePattern) {
+    this.setDateTimeFormatter(DateTimeFormatter.ofPattern(dateTimePattern));
+  }
+
+  public void setDateTimeOffsetPattern(String dateTimeOffsetPattern) {
+    this.setDateTimeOffsetFormatter(DateTimeFormatter.ofPattern(dateTimeOffsetPattern));
+  }
+
+  public void setTimePattern(String timePattern) {
+    this.setTimeFormatter(DateTimeFormatter.ofPattern(timePattern));
+  }
+
+  public static Jsr310ModuleConfigBuilder builder() {
+    return new Jsr310ModuleConfigBuilder();
+  }
+
+  public static class Jsr310ModuleConfigBuilder {
+
+    private DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(DEFAULT_DATE_PATTERN);
+    private DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DEFAULT_DATE_TIME_PATTERN);
+    private DateTimeFormatter dateTimeOffsetFormatter = DateTimeFormatter.ofPattern(DEFAULT_DATE_TIME_OFFSET_PATTERN);
+    private DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern(DEFAULT_TIME_PATTERN);
+    private ZoneId zoneId = ZoneId.systemDefault();
+
+    public Jsr310ModuleConfigBuilder datePattern(String datePattern) {
+      return this.dateFormatter(DateTimeFormatter.ofPattern(datePattern));
+    }
+
+    public Jsr310ModuleConfigBuilder dateFormatter(DateTimeFormatter dateFormatter) {
+      this.dateFormatter = dateFormatter;
+      return this;
+    }
+
+    public Jsr310ModuleConfigBuilder dateTimePattern(String dateTimePattern) {
+      return this.dateTimeFormatter(DateTimeFormatter.ofPattern(dateTimePattern));
+    }
+
+    public Jsr310ModuleConfigBuilder dateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+      this.dateTimeFormatter = dateTimeFormatter;
+      return this;
+    }
+
+    public Jsr310ModuleConfigBuilder dateTimeOffsetPattern(String dateTimeOffsetPattern) {
+      return this.dateTimeOffsetFormatter(DateTimeFormatter.ofPattern(dateTimeOffsetPattern));
+    }
+
+    public Jsr310ModuleConfigBuilder dateTimeOffsetFormatter(DateTimeFormatter dateTimeOffsetFormatter) {
+      this.dateTimeOffsetFormatter = dateTimeOffsetFormatter;
+      return this;
+    }
+
+    public Jsr310ModuleConfigBuilder timePattern(String timePattern) {
+      return this.timeFormatter(DateTimeFormatter.ofPattern(timePattern));
+    }
+
+    public Jsr310ModuleConfigBuilder timeFormatter(DateTimeFormatter timeFormatter) {
+      this.timeFormatter = timeFormatter;
+      return this;
+    }
+
+    public Jsr310ModuleConfigBuilder zoneId(ZoneId zoneId) {
+      this.zoneId = zoneId;
+      return this;
+    }
+
+    public Jsr310ModuleConfig build() {
+      return new Jsr310ModuleConfig(dateFormatter, dateTimeFormatter, dateTimeOffsetFormatter, timeFormatter, zoneId);
+    }
+  }
 }

--- a/datetime/src/main/java/org/modelmapper/module/jsr310/ToTemporalConverter.java
+++ b/datetime/src/main/java/org/modelmapper/module/jsr310/ToTemporalConverter.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.Date;
@@ -85,7 +84,7 @@ public class ToTemporalConverter implements ConditionalConverter<Object, Tempora
     Class<?> sourceType = source.getClass();
     if (sourceType.equals(String.class))
       return LocalDate.parse((String) source,
-          DateTimeFormatter.ofPattern(config.getDatePattern()));
+          config.getDateFormatter());
     return convertInstant(mappingContext).atZone(config.getZoneId()).toLocalDate();
   }
 
@@ -94,7 +93,7 @@ public class ToTemporalConverter implements ConditionalConverter<Object, Tempora
     Class<?> sourceType = source.getClass();
     if (sourceType.equals(String.class))
       return LocalDateTime.parse((String) source,
-          DateTimeFormatter.ofPattern(config.getDateTimePattern()));
+          config.getDateTimeFormatter());
     return convertInstant(mappingContext).atZone(config.getZoneId()).toLocalDateTime();
   }
 
@@ -103,7 +102,7 @@ public class ToTemporalConverter implements ConditionalConverter<Object, Tempora
     Class<?> sourceType = source.getClass();
     if (sourceType.equals(String.class))
       return OffsetDateTime.parse((String) source,
-              DateTimeFormatter.ofPattern(config.getDateTimeOffsetPattern()));
+              config.getDateTimeOffsetFormatter());
     return convertInstant(mappingContext).atZone(config.getZoneId()).toOffsetDateTime();
   }
 
@@ -112,7 +111,7 @@ public class ToTemporalConverter implements ConditionalConverter<Object, Tempora
     Class<?> sourceType = source.getClass();
     if (sourceType.equals(String.class))
       return LocalDateTime.parse((String) source,
-          DateTimeFormatter.ofPattern(config.getDateTimePattern()))
+          config.getDateTimeFormatter())
           .atZone(config.getZoneId()).toInstant();
     else if (Date.class.isAssignableFrom(sourceType))
       return Instant.ofEpochMilli(((Date) source).getTime());


### PR DESCRIPTION
Fixes issue #2 

Allowing only String patterns severely limits the capability of `DateTimeFormatter` as it prevents features such as variable length tokens, case insensitivity, etc. as well as use of the predefined ISO/RFC formats. These changes add support for setting `DateTimeFormatter`s in `Jsr310ModuleConfig` and `Jsr310ModuleConfigBuilder` while retaining as much pattern functionality as possible to avoid breaking existing logic.