### PR TITLE
Handles null for Temporal -> other type converter : return null

### DIFF
--- a/datetime/src/main/java/org/modelmapper/module/jsr310/ToTemporalConverter.java
+++ b/datetime/src/main/java/org/modelmapper/module/jsr310/ToTemporalConverter.java
@@ -36,6 +36,9 @@ public class ToTemporalConverter implements ConditionalConverter<Object, Tempora
 
   @Override
   public Temporal convert(MappingContext<Object, Temporal> mappingContext) {
+    if (mappingContext.getSource() == null)
+      return null;
+
     Class<?> destinationType = mappingContext.getDestinationType();
     if (LocalDateTime.class.equals(destinationType))
       return localDateTimeConverter.convert(mappingContext);

--- a/datetime/src/test/java/org/modelmapper/module/jsr310/ToInstantConverterTest.java
+++ b/datetime/src/test/java/org/modelmapper/module/jsr310/ToInstantConverterTest.java
@@ -11,6 +11,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 @Test
 public class ToInstantConverterTest {
@@ -75,5 +76,11 @@ public class ToInstantConverterTest {
     Instant instant = (Instant) converter.convert(TestHelper.unsafeMappingContext(
         calendar, Calendar.class, Instant.class));
     assertEquals(instant.toEpochMilli(), 1514764800000L);
+  }
+
+  public void shouldConvertNull() {
+    Instant timestamp = (Instant) converter.convert(TestHelper.unsafeMappingContext(
+            null, Date.class, Instant.class));
+    assertNull(timestamp);
   }
 }

--- a/datetime/src/test/java/org/modelmapper/module/jsr310/ToLocalDateConverterTest.java
+++ b/datetime/src/test/java/org/modelmapper/module/jsr310/ToLocalDateConverterTest.java
@@ -1,6 +1,7 @@
 package org.modelmapper.module.jsr310;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -75,5 +76,11 @@ public class ToLocalDateConverterTest {
     LocalDate localDate = (LocalDate) converter.convert(TestHelper.unsafeMappingContext(
         calendar, Calendar.class, LocalDate.class));
     assertEquals(localDate.atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(), 1514764800000L);
+  }
+
+  public void shouldConvertNull() {
+    LocalDate timestamp = (LocalDate) converter.convert(TestHelper.unsafeMappingContext(
+            null, Date.class, LocalDate.class));
+    assertNull(timestamp);
   }
 }

--- a/datetime/src/test/java/org/modelmapper/module/jsr310/ToLocalDateTimeConverterTest.java
+++ b/datetime/src/test/java/org/modelmapper/module/jsr310/ToLocalDateTimeConverterTest.java
@@ -1,6 +1,7 @@
 package org.modelmapper.module.jsr310;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -75,5 +76,11 @@ public class ToLocalDateTimeConverterTest {
     LocalDateTime localDateTime = (LocalDateTime) converter.convert(TestHelper.unsafeMappingContext(
         calendar, Calendar.class, LocalDateTime.class));
     assertEquals(localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli(), 1514764800000L);
+  }
+
+  public void shouldConvertNull() {
+    LocalDateTime timestamp = (LocalDateTime) converter.convert(TestHelper.unsafeMappingContext(
+            null, Date.class, LocalDateTime.class));
+    assertNull(timestamp);
   }
 }

--- a/datetime/src/test/java/org/modelmapper/module/jsr310/ToOffsetDateTimeConverterTest.java
+++ b/datetime/src/test/java/org/modelmapper/module/jsr310/ToOffsetDateTimeConverterTest.java
@@ -12,6 +12,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 @Test
 public class ToOffsetDateTimeConverterTest {
@@ -75,5 +76,11 @@ public class ToOffsetDateTimeConverterTest {
     OffsetDateTime offsetDateTime = (OffsetDateTime) converter.convert(TestHelper.unsafeMappingContext(
         calendar, Calendar.class, OffsetDateTime.class));
     assertEquals(offsetDateTime.toInstant().toEpochMilli(), 1514764800000L);
+  }
+
+  public void shouldConvertNull() {
+    OffsetDateTime timestamp = (OffsetDateTime) converter.convert(TestHelper.unsafeMappingContext(
+            null, Date.class, OffsetDateTime.class));
+    assertNull(timestamp);
   }
 }


### PR DESCRIPTION
Fixed null part of #13 same as [Handles null for date -> other type converter : return null](https://github.com/modelmapper/modelmapper-module-java8/commit/8facb95b6fc6f8487d422e97d78561df5ed20e2e)